### PR TITLE
[最終課題]商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: %i[new create]
 
   def index
-    # @item = Item.all
+    @item = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,11 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# @item.each do |item| %>
+      <% @item.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-           <%#= image_tag item.image, class: 'item-img' if item.image.attached? %>
+           <%= image_tag item.image, class: 'item-img' if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +141,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%#= item.name %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%#= item.price %>円<br><%#= item.shipping_cost.name %></span>
+            <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,9 +153,9 @@
         </div>
         <% end %>
       </li>
-      <%# end %>
+      <% end %>
 
-      <%# if @item.empty?  %>
+      <% if @item.empty?  %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -173,7 +173,7 @@
         </div>
         <% end %>
       </li>
-      <%# end %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
[最終課題]商品一覧表示機能の実装です。
確認をお願い致します。

### 出品した商品の一覧表示ができていること
### 「画像/価格/商品名」の3つの情報について表示できていること
###  売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
![スクリーンショット 2020-12-03 15 33 50](https://user-images.githubusercontent.com/69082303/100973427-df642b00-357d-11eb-98cc-a15ce9879891.png)

### 画像が表示されており、画像がリンク切れなどになっていないこと
![30e2f5a90d62bbe63d788acab85b9225](https://user-images.githubusercontent.com/69082303/100973161-6369e300-357d-11eb-9b5c-2ec6538d26cd.gif)
### 上から、出品された日時が新しい順に表示されること
![309f4898741bce43900a9fe3de80b711](https://user-images.githubusercontent.com/69082303/100973244-8d230a00-357d-11eb-8a6f-834f1e41b634.gif)
### ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
![e6801492aca68842f63326914bb2da02](https://user-images.githubusercontent.com/69082303/100973317-b04db980-357d-11eb-9858-1c9b615e9a30.gif)
